### PR TITLE
Remove the tasks, mini_sites, and field_reports from the user endpoint. Replace them with counts.

### DIFF
--- a/watershed-rails/app/serializers/users/user_serializer.rb
+++ b/watershed-rails/app/serializers/users/user_serializer.rb
@@ -1,5 +1,20 @@
 class UserSerializer < BaseUserSerializer
-  has_many :tasks
-  has_many :mini_sites
-  has_many :field_reports
+  # has_many :tasks
+  # has_many :mini_sites
+  # has_many :field_reports
+
+  attributes :tasks_count, :mini_sites_count, :field_reports_count
+
+  def tasks_count
+    object.tasks.count
+  end
+
+  def mini_sites_count
+    object.mini_sites.count
+  end
+
+  def field_reports_count
+    object.field_reports.count
+  end
+
 end


### PR DESCRIPTION
Fix #266 

Counts are necessary because we should show table view cells to open up the list of tasks, mini_sites, and field_reports that the user has and a count is a nice thing to show.
