### PR TITLE
Add created_at to json responses for tasks, users, photos, field_reports

### DIFF
--- a/watershed-rails/app/serializers/field_reports/base_field_report_serializer.rb
+++ b/watershed-rails/app/serializers/field_reports/base_field_report_serializer.rb
@@ -1,4 +1,5 @@
 class BaseFieldReportSerializer < ActiveModel::Serializer
   attributes :id, :user_id, :mini_site_id, :task_id,
-             :description, :health_rating, :urgent
+             :description, :health_rating, :urgent,
+             :created_at
 end

--- a/watershed-rails/app/serializers/photos/base_photo_serializer.rb
+++ b/watershed-rails/app/serializers/photos/base_photo_serializer.rb
@@ -1,3 +1,3 @@
 class BasePhotoSerializer < ActiveModel::Serializer
-  attributes :id, :url
+  attributes :id, :url, :created_at
 end

--- a/watershed-rails/app/serializers/tasks/base_task_serializer.rb
+++ b/watershed-rails/app/serializers/tasks/base_task_serializer.rb
@@ -1,6 +1,6 @@
 class BaseTaskSerializer < ActiveModel::Serializer
   attributes :id, :title, :description, :site_id,
-             :complete, :due_date, :urgent
+             :complete, :due_date, :urgent, :created_at
 
   has_one :assignee, serializer: UserListSerializer
   has_one :assigner, serializer: UserListSerializer

--- a/watershed-rails/app/serializers/users/base_user_serializer.rb
+++ b/watershed-rails/app/serializers/users/base_user_serializer.rb
@@ -1,5 +1,5 @@
 class BaseUserSerializer < ActiveModel::Serializer
-  attributes :id, :name, :email, :role
+  attributes :id, :name, :email, :role, :created_at
 
   def role
     object[:role]


### PR DESCRIPTION
We said it was only necessary for photos and field_reports, but I think tasks and users probably want to know too. For users, we can say something like: "Watersheding since Nov 2014" or something more professional like "Member since Nov 2014"

For tasks, a created at date is good for knowing how old it is.

Fix #325 
Fix #326 
