### PR TITLE
Max/move add task button

### DIFF
--- a/watershed-android/watershed/app/app.iml
+++ b/watershed-android/watershed/app/app.iml
@@ -10,9 +10,10 @@
       <configuration>
         <option name="SELECTED_BUILD_VARIANT" value="debug" />
         <option name="ASSEMBLE_TASK_NAME" value="assembleDebug" />
-        <option name="COMPILE_JAVA_TASK_NAME" value="compileDebugJava" />
+        <option name="COMPILE_JAVA_TASK_NAME" value="compileDebugSources" />
         <option name="ASSEMBLE_TEST_TASK_NAME" value="assembleDebugTest" />
         <option name="SOURCE_GEN_TASK_NAME" value="generateDebugSources" />
+        <option name="TEST_SOURCE_GEN_TASK_NAME" value="generateDebugTestSources" />
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
         <option name="MANIFEST_FILE_RELATIVE_PATH" value="/src/main/AndroidManifest.xml" />
         <option name="RES_FOLDER_RELATIVE_PATH" value="/src/main/res" />
@@ -30,29 +31,31 @@
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/debug" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/debug" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/debug" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/generated/debug" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/test/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/test/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/test/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/test/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/test/debug" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/generated/test/debug" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/debug/assets" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/aidl" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/debug/assets" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/assets" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/aidl" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/main/assets" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
@@ -76,6 +79,7 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 19 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/watershed-android/watershed/app/build.gradle
+++ b/watershed-android/watershed/app/build.gradle
@@ -14,7 +14,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }

--- a/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/AboutFragment.java
+++ b/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/AboutFragment.java
@@ -5,6 +5,8 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -24,6 +26,7 @@ public class AboutFragment extends Fragment{
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
+        setHasOptionsMenu(true);
         super.onCreate(savedInstanceState);
     }
 
@@ -53,6 +56,14 @@ public class AboutFragment extends Fragment{
 
     public interface OnFragmentInteractionListener {
         public void onFragmentInteraction(Uri uri);
+    }
+
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        menu.clear();
+        inflater.inflate(R.menu.empty, menu);
+        super.onCreateOptionsMenu(menu, inflater);
+
     }
 
 }

--- a/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/Activities/MainActivity.java
+++ b/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/Activities/MainActivity.java
@@ -16,6 +16,7 @@ import android.support.v7.app.ActionBarActivity;
 import android.support.v4.view.ViewPager;
 import android.util.Log;
 import android.view.Menu;
+import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.content.SharedPreferences;
 import android.graphics.Typeface;
@@ -290,6 +291,12 @@ public class MainActivity extends ActionBarActivity
                     getSupportFragmentManager().popBackStack();
                     return false;
                 }
+                break;
+            case R.id.add_task:
+                CreateTaskFragment newTask = CreateTaskFragment.newInstance();
+                replaceFragment(newTask);
+                return true;
+
         }
         if (mDrawerToggle.onOptionsItemSelected(item)) {
             return true;

--- a/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/FieldReports/AddFieldReportFragment.java
+++ b/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/FieldReports/AddFieldReportFragment.java
@@ -11,6 +11,8 @@ import android.provider.MediaStore;
 import android.support.v4.app.Fragment;
 import android.util.Log;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
@@ -70,6 +72,7 @@ public class AddFieldReportFragment extends Fragment implements View.OnClickList
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setHasOptionsMenu(true);
         mNetworkManager = NetworkManager.getInstance(getActivity().getApplicationContext());
         mActivity = (MainActivity) getActivity();
     }
@@ -155,6 +158,14 @@ public class AddFieldReportFragment extends Fragment implements View.OnClickList
                 startActivityForResult(takePictureIntent, CAMERA_REQUEST);
             }
         }
+    }
+
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        menu.clear();
+        inflater.inflate(R.menu.empty, menu);
+        super.onCreateOptionsMenu(menu, inflater);
+
     }
 
     public void onSubmitFieldReportButtonPressed(View fieldReportButton){

--- a/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/FieldReports/FieldReportFragment.java
+++ b/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/FieldReports/FieldReportFragment.java
@@ -4,6 +4,8 @@ import android.app.Activity;
 import android.net.Uri;
 import android.os.Bundle;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.support.v4.app.Fragment;
@@ -58,6 +60,7 @@ public class FieldReportFragment extends Fragment implements AbsListView.OnItemC
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setHasOptionsMenu(true);
         mNetworkManager = NetworkManager.getInstance(getActivity().getApplicationContext());
     }
 
@@ -68,6 +71,13 @@ public class FieldReportFragment extends Fragment implements AbsListView.OnItemC
         configureViewWithFieldReport(view, mFieldReport);
 
         return view;
+    }
+
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        menu.clear();
+        inflater.inflate(R.menu.empty, menu);
+        super.onCreateOptionsMenu(menu, inflater);
     }
 
     public void onButtonPressed(Uri uri) {

--- a/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/MiniSites/MiniSiteFragment.java
+++ b/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/MiniSites/MiniSiteFragment.java
@@ -4,6 +4,8 @@ import android.app.Activity;
 import android.net.Uri;
 import android.os.Bundle;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.support.v4.app.Fragment;
@@ -63,6 +65,7 @@ public class MiniSiteFragment extends Fragment
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setHasOptionsMenu(true);
         mNetworkManager = NetworkManager.getInstance(getActivity().getApplicationContext());
     }
 
@@ -105,6 +108,13 @@ public class MiniSiteFragment extends Fragment
             throw new ClassCastException(activity.toString()
                     + " must implement OnFragmentInteractionListener");
         }
+    }
+
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        menu.clear();
+        inflater.inflate(R.menu.empty, menu);
+        super.onCreateOptionsMenu(menu, inflater);
     }
 
     @Override

--- a/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/Networking/Sites/CreateSiteRequest.java
+++ b/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/Networking/Sites/CreateSiteRequest.java
@@ -1,4 +1,4 @@
-package com.blueprint.watershed.Networking.Tasks;
+package com.blueprint.watershed.Networking.Sites;
 
 import android.app.Activity;
 import android.util.Log;
@@ -7,8 +7,7 @@ import com.android.volley.Request;
 import com.android.volley.Response;
 import com.blueprint.watershed.Activities.MainActivity;
 import com.blueprint.watershed.Networking.BaseRequest;
-import com.blueprint.watershed.Tasks.Task;
-import com.blueprint.watershed.Tasks.TaskFragment;
+import com.blueprint.watershed.Sites.Site;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -17,40 +16,40 @@ import org.json.JSONObject;
 import java.util.HashMap;
 
 /**
- * Created by Max Wolffe on 12/8/14.
+ * Created by maxwolffe on 2/16/15.
  */
-public class CreateTaskRequest extends BaseRequest {
-
-    Task mTask;
+public class CreateSiteRequest extends BaseRequest {
+    Site mSite;
     Activity mActivity;
 
-    public CreateTaskRequest(final Activity activity, final Task task, HashMap<String, JSONObject> params, final Response.Listener<Task> listener) {
-        super(Request.Method.POST, makeURL("tasks"), taskParams(activity, task),
+    public CreateSiteRequest(final Activity activity, final Site site, HashMap<String, JSONObject> params, final Response.Listener<Site> listener) {
+        super(Request.Method.POST, makeURL("sites"), siteParams(activity, site),
                 new Response.Listener<JSONObject>() {
                     @Override
                     public void onResponse(JSONObject jsonObject) {
                         try {
-                            String taskJson = jsonObject.get("task").toString();
+                            String siteJson = jsonObject.get("site").toString();
                             ObjectMapper mapper = getNetworkManager(activity.getApplicationContext()).getObjectMapper();
-                            Task task = mapper.readValue(taskJson, new TypeReference<Task>() {
+                            Site site = mapper.readValue(siteJson, new TypeReference<Site>() {
                             });
-                            listener.onResponse(task);
+                            listener.onResponse(site);
                         } catch (Exception e) {
                             Log.e("Json exception", e.toString());
                         }
                     }
                 }, activity);
+
+        mSite = site;
         mActivity = activity;
-        mTask = task;
     }
 
-    protected static JSONObject taskParams(final Activity activity, final Task task) {
+    protected static JSONObject siteParams(final Activity activity, final Site site) {
         HashMap<String, JSONObject> params = new HashMap<String, JSONObject>();
         ObjectMapper mapper = getNetworkManager(activity.getApplicationContext()).getObjectMapper();
 
         try {
-            JSONObject taskJson = new JSONObject(mapper.writeValueAsString(task));
-            params.put("task", taskJson);
+            JSONObject siteJson = new JSONObject(mapper.writeValueAsString(site));
+            params.put("site", siteJson);
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -58,3 +57,4 @@ public class CreateTaskRequest extends BaseRequest {
         return new JSONObject(params);
     }
 }
+

--- a/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/Networking/Sites/CreateSiteRequest.java
+++ b/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/Networking/Sites/CreateSiteRequest.java
@@ -47,7 +47,7 @@ public class CreateSiteRequest extends BaseRequest {
      * Generates a JSON object of the created site to be sent to the server.
      * @param activity
      * @param site - site object to be created.
-     * @return
+     * @return Site Json object with site parameters
      */
     protected static JSONObject siteParams(final Activity activity, final Site site) {
         HashMap<String, JSONObject> params = new HashMap<String, JSONObject>();

--- a/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/Networking/Sites/CreateSiteRequest.java
+++ b/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/Networking/Sites/CreateSiteRequest.java
@@ -43,6 +43,12 @@ public class CreateSiteRequest extends BaseRequest {
         mActivity = activity;
     }
 
+    /**
+     * Generates a JSON object of the created site to be sent to the server.
+     * @param activity
+     * @param site - site object to be created.
+     * @return
+     */
     protected static JSONObject siteParams(final Activity activity, final Site site) {
         HashMap<String, JSONObject> params = new HashMap<String, JSONObject>();
         ObjectMapper mapper = getNetworkManager(activity.getApplicationContext()).getObjectMapper();

--- a/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/Networking/Sites/CreateSiteRequest.java
+++ b/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/Networking/Sites/CreateSiteRequest.java
@@ -22,6 +22,14 @@ public class CreateSiteRequest extends BaseRequest {
     Site mSite;
     Activity mActivity;
 
+    /**
+     * Sends a request to the server to create a new site.
+     *
+     * @param activity - typically MainActivity, an activity that has a network manager.
+     * @param site - site to be created
+     * @param params - params for a new site. JSON Object
+     * @param listener - A response listener to be called once the reponse is returned.
+     */
     public CreateSiteRequest(final Activity activity, final Site site, HashMap<String, JSONObject> params, final Response.Listener<Site> listener) {
         super(Request.Method.POST, makeURL("sites"), siteParams(activity, site),
                 new Response.Listener<JSONObject>() {

--- a/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/Networking/Tasks/CreateTaskRequest.java
+++ b/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/Networking/Tasks/CreateTaskRequest.java
@@ -24,6 +24,14 @@ public class CreateTaskRequest extends BaseRequest {
     Task mTask;
     Activity mActivity;
 
+    /**
+     * Sends a request to the server to create a new task.
+     *
+     * @param activity - typically MainActivity, an activity that has a network manager.
+     * @param task - task to be created
+     * @param params - params for a new site. JSON Object
+     * @param listener - A response listener to be called once the reponse is returned.
+     */
     public CreateTaskRequest(final Activity activity, final Task task, HashMap<String, JSONObject> params, final Response.Listener<Task> listener) {
         super(Request.Method.POST, makeURL("tasks"), taskParams(activity, task),
                 new Response.Listener<JSONObject>() {

--- a/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/Networking/Tasks/CreateTaskRequest.java
+++ b/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/Networking/Tasks/CreateTaskRequest.java
@@ -48,7 +48,7 @@ public class CreateTaskRequest extends BaseRequest {
      * Generates a JSON object of the created task to be sent to the server.
      * @param activity
      * @param task - task object to be created.
-     * @return
+     * @return Task Json object with task parameters
      */
     protected static JSONObject taskParams(final Activity activity, final Task task) {
         HashMap<String, JSONObject> params = new HashMap<String, JSONObject>();

--- a/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/Networking/Tasks/CreateTaskRequest.java
+++ b/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/Networking/Tasks/CreateTaskRequest.java
@@ -44,6 +44,12 @@ public class CreateTaskRequest extends BaseRequest {
         mTask = task;
     }
 
+    /**
+     * Generates a JSON object of the created task to be sent to the server.
+     * @param activity
+     * @param task - task object to be created.
+     * @return
+     */
     protected static JSONObject taskParams(final Activity activity, final Task task) {
         HashMap<String, JSONObject> params = new HashMap<String, JSONObject>();
         ObjectMapper mapper = getNetworkManager(activity.getApplicationContext()).getObjectMapper();

--- a/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/Sites/SiteFragment.java
+++ b/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/Sites/SiteFragment.java
@@ -5,6 +5,8 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.support.v4.app.Fragment;
@@ -65,7 +67,7 @@ public class SiteFragment extends Fragment
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setHasOptionsMenu(false);
+        setHasOptionsMenu(true);
         mNetworkManager = NetworkManager.getInstance(getActivity().getApplicationContext());
     }
 
@@ -141,7 +143,6 @@ public class SiteFragment extends Fragment
     // Networking
     public void getSiteRequest(Site site) {
         HashMap<String, JSONObject> params = new HashMap<String, JSONObject>();
-
         SiteRequest siteRequest = new SiteRequest(getActivity(), site, params, new Response.Listener<Site>() {
             @Override
             public void onResponse(Site site) {
@@ -173,5 +174,13 @@ public class SiteFragment extends Fragment
         for (MiniSite miniSite : miniSites) {
             mMiniSites.add(miniSite);
         }
+    }
+
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        menu.clear();
+        inflater.inflate(R.menu.empty, menu);
+        super.onCreateOptionsMenu(menu, inflater);
+
     }
 }

--- a/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/Sites/SiteListFragment.java
+++ b/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/Sites/SiteListFragment.java
@@ -93,7 +93,10 @@ public class SiteListFragment extends Fragment {
 
     @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
-        inflater.inflate(R.menu.create_task_menu, menu);
+        menu.clear();
+        inflater.inflate(R.menu.empty, menu);
+        super.onCreateOptionsMenu(menu, inflater);
+
     }
 
     public void getSitesRequest() {

--- a/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/Tasks/CreateTaskFragment.java
+++ b/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/Tasks/CreateTaskFragment.java
@@ -5,6 +5,8 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.support.v4.app.Fragment;
@@ -46,6 +48,7 @@ public class CreateTaskFragment extends Fragment implements View.OnClickListener
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setHasOptionsMenu(true);
         mNetworkManager = NetworkManager.getInstance(getActivity().getApplicationContext());
         mMainActivity = (MainActivity) getActivity();
     }
@@ -68,6 +71,13 @@ public class CreateTaskFragment extends Fragment implements View.OnClickListener
             throw new ClassCastException(activity.toString()
                     + " must implement OnFragmentInteractionListener");
         }
+    }
+
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        menu.clear();
+        inflater.inflate(R.menu.empty, menu);
+        super.onCreateOptionsMenu(menu, inflater);
     }
 
     @Override

--- a/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/Tasks/TaskDetailFragment.java
+++ b/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/Tasks/TaskDetailFragment.java
@@ -34,7 +34,9 @@ public class TaskDetailFragment extends Fragment implements View.OnClickListener
 
     @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
-        inflater.inflate(R.menu.create_task_menu, menu);
+        menu.clear();
+        inflater.inflate(R.menu.empty, menu);
+        super.onCreateOptionsMenu(menu, inflater);
     }
 
     public TaskDetailFragment() {
@@ -93,21 +95,6 @@ public class TaskDetailFragment extends Fragment implements View.OnClickListener
     @Override
     public void onResume() {
         super.onResume();
-        //TODO make Task request. Do we need to get anything else from the server for this?
-    }
-
-    //TODO Move this method to TaskFragment once the duplicate menu items bug is fixed.
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        // Handle item selection
-        switch (item.getItemId()) {
-            case R.id.add_task:
-                CreateTaskFragment newTask = CreateTaskFragment.newInstance();
-                ((MainActivity)getActivity()).replaceFragment(newTask);
-                return true;
-            default:
-                return super.onOptionsItemSelected(item);
-        }
     }
 
     // Button Events

--- a/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/Tasks/TaskFragment.java
+++ b/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/Tasks/TaskFragment.java
@@ -48,7 +48,6 @@ public class TaskFragment extends ListFragment {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        Log.e("onCreate Called", "Again");
         setHasOptionsMenu(true);
         mNetworkManager = NetworkManager.getInstance(getActivity().getApplicationContext());
         parentActivity = (MainActivity)getActivity();

--- a/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/Tasks/TaskFragment.java
+++ b/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/Tasks/TaskFragment.java
@@ -48,7 +48,8 @@ public class TaskFragment extends ListFragment {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        //setHasOptionsMenu(true);
+        Log.e("onCreate Called", "Again");
+        setHasOptionsMenu(true);
         mNetworkManager = NetworkManager.getInstance(getActivity().getApplicationContext());
         parentActivity = (MainActivity)getActivity();
         mTaskList = new ArrayList<Task>();
@@ -71,7 +72,6 @@ public class TaskFragment extends ListFragment {
         View finalView = inflater.inflate(R.layout.fragment_task_list, container, false);
         listView1 = (ListView)finalView.findViewById(android.R.id.list);
         mTaskAdapter = new TaskAdapter(getActivity(),R.layout.task_list_row, mTaskList);
-
         listView1.setAdapter(mTaskAdapter);
         return finalView;
     }
@@ -104,9 +104,10 @@ public class TaskFragment extends ListFragment {
 
     @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        menu.clear();
         inflater.inflate(R.menu.create_task_menu, menu);
+        super.onCreateOptionsMenu(menu, inflater);
     }
-
 
     @Override
     public void onDetach() {
@@ -125,7 +126,6 @@ public class TaskFragment extends ListFragment {
                 mTaskAdapter.notifyDataSetChanged();
             }
         });
-
         mNetworkManager.getRequestQueue().add(taskListRequest);
     }
 

--- a/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/Users/UserFragment.java
+++ b/watershed-android/watershed/app/src/main/java/com/blueprint/watershed/Users/UserFragment.java
@@ -6,6 +6,8 @@ import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.util.Log;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
@@ -44,6 +46,7 @@ public class UserFragment extends Fragment implements ListView.OnItemClickListen
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         mMainActivity = (MainActivity) getActivity();
+        setHasOptionsMenu(true);
         mNetworkManager = NetworkManager.getInstance(getActivity().getApplicationContext());
     }
 
@@ -92,6 +95,14 @@ public class UserFragment extends Fragment implements ListView.OnItemClickListen
             throw new ClassCastException(activity.toString()
                     + " must implement OnFragmentInteractionListener");
         }
+    }
+
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        menu.clear();
+        inflater.inflate(R.menu.empty, menu);
+        super.onCreateOptionsMenu(menu, inflater);
+
     }
 
 

--- a/watershed-android/watershed/app/src/main/res/menu/create_task_menu.xml
+++ b/watershed-android/watershed/app/src/main/res/menu/create_task_menu.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto" >
+    xmlns:app="http://schemas.android.com/apk/res-auto">
     <item android:id="@+id/add_task"
         android:title="Add Task"
         android:icon="@drawable/ic_action_edit"

--- a/watershed-android/watershed/app/src/main/res/menu/empty.xml
+++ b/watershed-android/watershed/app/src/main/res/menu/empty.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+</menu>

--- a/watershed-android/watershed/build.gradle
+++ b/watershed-android/watershed/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.12.2'
+        classpath 'com.android.tools.build:gradle:1.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/watershed-android/watershed/gradle/wrapper/gradle-wrapper.properties
+++ b/watershed-android/watershed/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Mon Jan 05 18:00:40 PST 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/watershed-android/watershed/watershed.iml
+++ b/watershed-android/watershed/watershed.iml
@@ -7,7 +7,9 @@
       </configuration>
     </facet>
   </component>
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
+  <component name="NewModuleRootManager" inherit-compiler-output="false">
+    <output url="file://$MODULE_DIR$/build/classes/main" />
+    <output-test url="file://$MODULE_DIR$/build/classes/test" />
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.gradle" />


### PR DESCRIPTION
Make app compatible with Android Studio 1.0
Move the add task button to only appear in the task list view. (required adding menu inflaters to all fragments, but I think that's ok. because we'll want to add creation buttons to some of the fragments anyway?)
Also, app is running out of memory, but I don't think that's an issue with this PR. 